### PR TITLE
Atualiza templates para aplicações Rails

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -1,7 +1,7 @@
 require: rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.6.3
+  TargetRubyVersion: 2.7.1
   DisplayCopNames: true
   Exclude:
     - 'db/schema.rb'

--- a/templates/rails/Dockerfile
+++ b/templates/rails/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.5-stretch
+FROM ruby:2.7.1-buster
 
 # Include variables
 ARG APP_NAME

--- a/templates/rails/templates/.circleci/config.yml
+++ b/templates/rails/templates/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     environment:
       CIRCLE_ENV: test
     docker:
-    - image: circleci/ruby:2.6.3-stretch-node
+    - image: circleci/ruby:2.7.1-buster-node
       environment:
         DATABASE_HOST: 127.0.0.1
         DATABASE_USERNAME: #{app_name}

--- a/templates/rails/templates/.codeclimate.yml
+++ b/templates/rails/templates/.codeclimate.yml
@@ -31,7 +31,7 @@ plugins:
     enabled: true
     # Manter a versão abaixo idêntica à gem usada no projeto. Ver disponíveis em
     # https://docs.codeclimate.com/docs/rubocop#section-using-rubocop-s-newer-versions
-    channel: rubocop-0-73
+    channel: rubocop-0-89
 exclude_patterns:
 - config/
 - db/

--- a/templates/rails/templates/Dockerfile
+++ b/templates/rails/templates/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.5-stretch
+FROM ruby:2.7.1-buster
 
 # Dependencies
 RUN docker="wait-for-it" \

--- a/templates/rails/templates/template.rb
+++ b/templates/rails/templates/template.rb
@@ -22,7 +22,7 @@ gem_group :development, :test do
   gem 'rspec-rails', '~> 3.8'
 
   ## Checkers
-  gem 'rubocop', require: false
+  gem 'rubocop', '~> 0.89', require: false
   gem 'rubocop-rspec', require: false
 end
 


### PR DESCRIPTION
## Motivação :muscle:

- Versão desatualziada do Ruby
- Quando uma nova aplicação é gerada, a versão do Rubocop do `Gemfile.lock` pode ser diferente da versão fixada no `.codeclimate.yml`

## Solução :wrench:

- Atualiza versão do Ruby nos arquivos de template
- Fixa a versão 0.89.1 do Rubocop no Gemfile e no template .codeclimate.yml.
  - Versões disponíveis do Rubocop usado no CodeClimate pode ser encontrada [no GitHub deles.](https://github.com/codeclimate/codeclimate-rubocop/branches/all?utf8=%E2%9C%93&query=channel%2Frubocop)

## Como testar :policeman:

- Siga os passos de 1 a 8 de [como criar uma nova aplicação usando o Rails Application Builder.](https://github.com/doghero/style_guides/tree/master/templates/rails#how-create-a-new-application)
- Na pasta do projeto, use o comando `docker-compose build` para criar uma imagem do projeto.
  - Não sei se vai acontecer com todo mundo mas eu recebi o seguinte erro:
    ```
     Cannot start service web: OCI runtime create failed: container_linux.go:349: starting container process caused "exec: \"./entrypoint.sh\": permission denied": unknown
    ```
    [Pesquisando na internet](https://pt.stackoverflow.com/a/410876), consegui resolver mudando a permissão do arquivo `entrypoint.sh` com o seguinte comando: `chmod +x entrypoint.sh`.
- Rode os seguintes comandos e cheque as saídas
  - comando: `docker-compose run --rm web ruby -v`
     saída: `ruby 2.7.1p83 (2020-03-31 revision a0c7c23c9c) [x86_64-linux]`
  - comando: `docker-compose run --rm web rails -v`
     saída: `Rails 6.0.3.2` (na verdade a saída desse comando é a [versão atual do Rails](https://rubyonrails.org/), que no momento é a 6.0.3.2). 
- Inicie a aplicação com `docker-compose up` e vá até `localhost:3000`
  - Se tudo der certo você verá uma página dizendo que precisa rodar as migrations 🤣 