### PR TITLE
Corrige variável de ambiente do Sentry

### DIFF
--- a/templates/rails/templates/initializers/2_sentry_config.rb
+++ b/templates/rails/templates/initializers/2_sentry_config.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Raven.configure do |config|
-  config.dsn = ENV.fetch('SENTRY_DNS') unless ['development', 'test'].include? Rails.env
+  config.dsn = ENV.fetch('SENTRY_DSN') unless ['development', 'test'].include? Rails.env
   config.logger = Logger.new('/dev/null')
   config.excluded_exceptions = []
   config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)

--- a/templates/rails/templates/template.rb
+++ b/templates/rails/templates/template.rb
@@ -38,7 +38,7 @@ file '.env', <<-CODE
   DATABASE_HOST=db
   DATABASE_USERNAME=#{app_name}
   DATABASE_PASSWORD=password
-  SENTRY_DNS=nil
+  SENTRY_DSN=nil
   CODE
 
 after_bundle do


### PR DESCRIPTION
## Motivação :muscle:

A variável de ambiente do Sentry está com o nome errado

## Solução :wrench:

Corrige variável de SENTRY_DNS para SENTRY_DSN. O DSN é de `Data Source Name`.